### PR TITLE
Wrap Salsa Exceptions thrown from Salsa to allow pretty-printing a salsa trace

### DIFF
--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -24,21 +24,6 @@ import MacroTools
 include("DebugMode.jl")
 import .DebugMode: @debug_mode, DBG
 
-struct SalsaDerivedException <: Base.Exception
-    captured_exception::Any
-    salsa_trace::Vector{Tuple}
-end
-function Base.showerror(io::IO, exc::SalsaDerivedException)
-    print(io, nameof(typeof(exc)))
-    println(io, ": Error encountered while executing Salsa derived function:")
-    Base.showerror(io, exc.captured_exception)
-    println(io, "\n\n------ Salsa Trace -----------------")
-    for (idx, call_args) in enumerate(reverse(exc.salsa_trace))
-        println(io, "[$idx] ", call_args)  # Uses pretty-printing for Traces defined below
-    end
-    println(io, "------------------------------------")
-end
-
 
 const Revision = Int
 
@@ -81,6 +66,22 @@ mutable struct DerivedValue{T}
 end
 
 _changed_at(v::DerivedValue)::Revision where T = v.changed_at
+
+struct SalsaDerivedException{T} <: Base.Exception
+    captured_exception::T
+    salsa_trace::Vector{DependencyKey}
+end
+function Base.showerror(io::IO, exc::SalsaDerivedException)
+    print(io, nameof(typeof(exc)))
+    println(io, ": Error encountered while executing Salsa derived function:")
+    Base.showerror(io, exc.captured_exception)
+    println(io, "\n\n------ Salsa Trace -----------------")
+    for (idx, call_args) in enumerate(exc.salsa_trace)
+        println(io, "[$idx] ", call_args)  # Uses pretty-printing for Traces defined below
+    end
+    println(io, "------------------------------------")
+end
+
 
 """
     abstract type AbstractComponent
@@ -217,7 +218,7 @@ function trace_with_key(f::Function, rt::Runtime, dbkey)
     catch e
         # Wrap the exception in a Salsa exception (at the lowest layer).
         if !(e isa SalsaDerivedException)
-            rethrow(SalsaDerivedException(e, rt.active_query))
+            rethrow(SalsaDerivedException{typeof(e)}(e, copy(rt.active_query)))
         else
             rethrow()
         end

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -76,7 +76,7 @@ function Base.showerror(io::IO, exc::SalsaDerivedException)
     println(io, ": Error encountered while executing Salsa derived function:")
     Base.showerror(io, exc.captured_exception)
     println(io, "\n\n------ Salsa Trace -----------------")
-    for (idx, call_args) in enumerate(exc.salsa_trace)
+    for (idx, call_args) in enumerate(reverse(exc.salsa_trace))
         println(io, "[$idx] ", call_args)  # Uses pretty-printing for Traces defined below
     end
     println(io, "------------------------------------")

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -1,7 +1,7 @@
 module SalsaTest
 
 using Salsa
-using Salsa: AbstractComponent, InputMap, InputScalar, @component, @input, @connect
+using Salsa: AbstractComponent, InputMap, InputScalar, @component, @input, @connect, SalsaDerivedException
 using BenchmarkTools
 using Profile
 using Testy
@@ -368,7 +368,7 @@ end
 
     # Setting a value that will cause square_root() to throw an Exception
     db.v[] = -1
-    @test_throws DomainError square_root(db)
+    @test_throws SalsaDerivedException{DomainError} square_root(db)
 
     # Now test that it's recovered gracefully from the error, and we can still use the DB
     db.v[] = 1
@@ -383,7 +383,7 @@ end
     db.v[] = -1
     db.m[1] = 2
     # Attempts 2 * sqrt(-1), and throws an error
-    @test_throws DomainError val_times_sqrt(db, 1)
+    @test_throws SalsaDerivedException{DomainError} val_times_sqrt(db, 1)
 
     # Now test that it's recovered gracefully from the error, and we can still use the DB
     db.v[] = 1
@@ -392,7 +392,7 @@ end
 
     # Now check that we also recover from KeyErrors when reading from a map:
     # Throw error:
-    @test_throws KeyError val_times_sqrt(db, 100)  # No key 100
+    @test_throws SalsaDerivedException{KeyError} val_times_sqrt(db, 100)  # No key 100
     # But this call still works:
     @test val_times_sqrt(db, 1) == 2  # 2 * sqrt(1)
 end
@@ -424,7 +424,7 @@ end
     # <Test that Salsa correctly throws an error given a programming bug>
     # Delete student only from student_grades but leave in all_student_ids (a programming error)
     delete!(state.student_grades, 2)
-    @test_throws KeyError average_grade(state)
+    @test_throws SalsaDerivedException{KeyError} average_grade(state)
 end
 
 # ----------------------------------
@@ -486,23 +486,23 @@ end
     # From within a derived function, calling anything but getindex fails:
 
     # Reflection functions throw an error on an empty map.
-    @test_throws ErrorException numelts(db)
-    @test_throws ErrorException mapvals(db)
-    @test_throws ErrorException valsum(db)
-    @test_throws ErrorException mapkeys(db)
-    @test_throws ErrorException keysum(db)
+    @test_throws SalsaDerivedException{ErrorException} numelts(db)
+    @test_throws SalsaDerivedException{ErrorException} mapvals(db)
+    @test_throws SalsaDerivedException{ErrorException} valsum(db)
+    @test_throws SalsaDerivedException{ErrorException} mapkeys(db)
+    @test_throws SalsaDerivedException{ErrorException} keysum(db)
     # The version that loops over the (k,v) items, and therefore actually touches them.
-    @test_throws ErrorException looped_valsum(db)
+    @test_throws SalsaDerivedException{ErrorException} looped_valsum(db)
 
     # If you update the values, calling anything but getindex still fails.
     db.map[1] = 10
     db.map[2] = 20
-    @test_throws ErrorException numelts(db)
-    @test_throws ErrorException mapvals(db)
-    @test_throws ErrorException valsum(db)
-    @test_throws ErrorException mapkeys(db)
-    @test_throws ErrorException keysum(db)
-    @test_throws ErrorException looped_valsum(db)
+    @test_throws SalsaDerivedException{ErrorException} numelts(db)
+    @test_throws SalsaDerivedException{ErrorException} mapvals(db)
+    @test_throws SalsaDerivedException{ErrorException} valsum(db)
+    @test_throws SalsaDerivedException{ErrorException} mapkeys(db)
+    @test_throws SalsaDerivedException{ErrorException} keysum(db)
+    @test_throws SalsaDerivedException{ErrorException} looped_valsum(db)
 end
 
 # ----------------------------------
@@ -614,7 +614,7 @@ end
 
     # Update `a` outside the db
     push!(a, 4)
-    @test_throws KeyError db.vec_to_int[a]
+    @test_throws SalsaDerivedException{KeyError} db.vec_to_int[a]
     @test_broken db.vec_to_int[[1,2,3]] == 1   # Something about the equality test being broken
 end
 
@@ -699,7 +699,7 @@ initial_grades = Dict("John"    =>  100,
 
         # Attempting to compute an average with an inconsistent manifest and map will throw
         # a KeyError:
-        @test_throws KeyError course_average(st)
+        @test_throws SalsaDerivedException{KeyError} course_average(st)
 
         st.all_names[] = ()
         @test isequal(course_average(st), nothing)  # Returns missing since nothing to average


### PR DESCRIPTION
The new exception printing now looks like this:

```julia
julia> val_times_sqrt(db, 1)  # Attempts 2 * sqrt(-1), and throws an error
ERROR: SalsaDerivedException: Error encountered while executing Salsa derived function:
DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).

------ Salsa Trace -----------------
[1] @derived val_times_sqrt(1::Any)
[2] @derived square_root()
------------------------------------

Stacktrace:
 [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:32
 [2] sqrt at ./math.jl:492 [inlined]
 [3] sqrt at ./math.jl:518 [inlined]
 [4] %%__user_square_root at /Users/nathan.daly/.julia/dev/Salsa/test/Salsa.jl:353 [inlined]
```

This is useful because Julia will elide the stacktrace if it is too repetitive, which our stack traces sometimes are if they're deep within salsa.