### PR TITLE
Fix bug in derived functions over multiple components.

### DIFF
--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -56,8 +56,8 @@ abstract type AbstractKey end
 # `AbstractComponent`, as is required for Derived functions.
 # Examples:
 #   foo(component,1,2,3) -> DependencyKey(key=DerivedKey{Foo, (MyComponent,Int,Int,Int)}(),
-#                                         args=(db, 1, 2, 3))
-#   db.map[1,2]    -> DependencyKey(key=InputKey{:map}(), args=(1, 2))
+#                                         args=(component, 1, 2, 3))
+#   component.map[1,2]    -> DependencyKey(key=InputKey{...}(component.map), args=(1, 2))
 Base.@kwdef struct DependencyKey{KT<:AbstractKey}
     key::KT
     args::Tuple

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -58,9 +58,9 @@ abstract type AbstractKey end
 #   foo(component,1,2,3) -> DependencyKey(key=DerivedKey{Foo, (MyComponent,Int,Int,Int)}(),
 #                                         args=(component, 1, 2, 3))
 #   component.map[1,2]    -> DependencyKey(key=InputKey{...}(component.map), args=(1, 2))
-Base.@kwdef struct DependencyKey{KT<:AbstractKey}
+Base.@kwdef struct DependencyKey{KT<:AbstractKey, ARG_T<:Tuple}
     key::KT
-    args::Tuple
+    args::ARG_T
 end
 # Note that floats should be compared for equality, not NaN-ness
 function Base.:(==)(x1::DependencyKey, x2::DependencyKey)

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -850,6 +850,13 @@ used as part of the macro processing. The macro is used to auto-generate a const
 correctly initializes the embedded Component. (The generated constructor simply passes the
 provided Runtime through to the Component's constructor.)
 
+The `@connect` macro is used by Salsa to automatically add initialization for the specified
+field in the auto-generated `Salsa.create(MyComponent)` function. e.g. given a declaration
+`@connect a :: A`, `create()` will automatically perform:
+```julia
+    out.a = A(runtime)
+```
+
 # Example
 ```julia
     Salsa.@component MyComponent begin

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -46,6 +46,8 @@ Salsa.@component Compiler begin
 end
 Salsa.@component Workspace begin
     Salsa.@input i2::Salsa.InputScalar{Int}
+    # NOTE: @connect is the simplest way to embed another component and make sure they have
+    # the same Runtime. It's important that they share the same runtime.
     Salsa.@connect compiler::Compiler
 end
 Salsa.@component TestStorage begin
@@ -786,16 +788,24 @@ end
     @connect a :: A
 end
 
-
-
+@derived function x_at(a::A, k)
+    a.x[k]
+end
+@derived function x_at(b::B, k)
+    b.a.x[k]
+end
 
 @testset "composed component" begin
     b = B()
     b.a.x[1] = 10
     @test b.a.x[1] == 10
+    @test x_at(b, 1) == 10
+    @test x_at(b.a, 1) == 10
+    b.a.x[1] = 20
+    @test b.a.x[1] == 20
+    @test x_at(b, 1) == 20
+    @test x_at(b.a, 1) == 20
 end
-
-
 
 # --------------------------------------------------
 # End of tests, start of benchmark


### PR DESCRIPTION
Fix bug in Salsa with calling derived functions across multiple components. For example, something like this is now okay:
```julia
    # Multi-level derived functions
    Salsa.@derived function outer(c::TestStorage)::Int
        # Call a derived function on an embedded component.
        foofunc(c.workspace, 2, Int[])
    end
```

To fix this, I added which component a derived function was called on to the tracked DependencyKeys. While i was there, i changed the DependencyKeys from a Tuple, to a proper struct, so that they're easier to use in the Salsa codebase. This meant i had to also add the `isequal`/`hash`/`isless` overloads to implement the reflective equality behavior we want.


--------------------

While I was there, I also improved the error printing to also print Salsa inputs as well, so for example attempting access this InputMap with name `"Nathan"` throws a `KeyError`, which is now clearly shown:

```julia
ERROR: SalsaDerivedException: Error encountered while executing Salsa derived function:
KeyError: key "Nathan" not found

------ Salsa Trace -----------------
[1] @input InputKey{Main.Salsa.InputMap{String,Float64}}(@0x0000000127e0de60)[("Nathan",)]
[2] @derived letter_grade2(::Classroom4, "Nathan"::String)
------------------------------------

Stacktrace:
 [1] getindex at ./dict.jl:477 [inlined]
```

This PR is opened as a follow-up to #1, which adds the exceptions and pretty-printing.