### PR TITLE
Add minimal README; share w/ Salsa module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 [![Build Status](https://travis-ci.com/RelationalAI-oss/Salsa.jl.svg?branch=master)](https://travis-ci.com/RelationalAI-oss/Salsa.jl)
 
+
+Implementation of a framework for incremental metadata computations via
+memoization, inspired by Rust lang's
+[salsa-rs/salsa](https://github.com/salsa-rs/salsa).
+
+- `@component`
+- `@derived`
+- `@input`
+

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 [![Build Status](https://travis-ci.com/RelationalAI-oss/Salsa.jl.svg?branch=master)](https://travis-ci.com/RelationalAI-oss/Salsa.jl)
 
-
-Implementation of a framework for incremental metadata computations via
-memoization, inspired by Rust lang's
+A framework for on-demand, incremental computation via memoization, inspired by Rust lang's
 [salsa-rs/salsa](https://github.com/salsa-rs/salsa).
 
 - `@component`
 - `@derived`
 - `@input`
 
+## Warning
+This package is in early stages of work-in-progress, and changing frequently.
+
+## Credits
+This package was closely modelled off of the Rust
+[`salsa`](https://github.com/salsa-rs/salsa) framework, and takes heavy inspiration from
+that framework and [adapton](http://adapton.org/).

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -1,14 +1,11 @@
-"""
-    module Salsa
-
-Implementation of a framework for incremental metadata computations via
-memoization, inspired by Rust's Salsa.
-
-* `@component`
-* `@derived`
-* `@input`
-"""
 module Salsa
+
+# Document this Module via the README.md file.
+@doc let path = joinpath(dirname(@__DIR__), "README.md")
+    include_dependency(path)
+    replace(read(path, String), "```julia" => "```jldoctest")
+end Salsa
+
 
 export @component, @input, @derived, @connect, AbstractComponent, InputScalar, InputMap
 


### PR DESCRIPTION
Move Salsa module docstring to README, and share README w/ docstring.

Expand to a basic README.