### PR TITLE
Fix bug in at-derived macro parsing methods w/ unnamed arguments.

### DIFF
--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -444,18 +444,17 @@ macro derived(f)
     dict = MacroTools.splitdef(f)
 
     fname = dict[:name]
-    args = dict[:args]
 
-    if length(args) < 1
+    if length(dict[:args]) < 1
         throw(ArgumentError("@derived functions must take a Component as the first argument."))
     end
 
     # _argnames and _argtypes fill in anonymous names for unnamed args (`::Int`) and `Any`
     # for untyped args. `fullargs` will have all args w/ names and types.
-    argnames = _argnames(args)
-    argtypes = _argtypes(args)
+    argnames = _argnames(dict[:args])
+    argtypes = _argtypes(dict[:args])
     dbname = argnames[1]
-    fullargs = [Expr(:(::), argnames[i], argtypes[i]) for i in 1:length(args)]
+    fullargs = [Expr(:(::), argnames[i], argtypes[i]) for i in 1:length(dict[:args])]
 
     # Get the argument types and return types for building the dictionary types.
     # TODO: IS IT okay to eval here? Will function defs always be top-level exprs?

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -503,7 +503,7 @@ macro derived(f)
             cache
         end
 
-        function $(@__MODULE__()).invoke_user_function(::$derived_key_t, $(args...))
+        function $(@__MODULE__()).invoke_user_function(::$derived_key_t, $(fullargs...))
             $userfname($(argnames[1]), $(argnames[2:end]...))
         end
 

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -527,16 +527,19 @@ end
 # ----------------------------------
 
 # Allow functions with multiple methods
-Salsa.@derived f(db::AbstractComponent) = 1
-Salsa.@derived f(db::AbstractComponent, arg::Any) = arg
-Salsa.@derived f(db::AbstractComponent, arg::Int) = 10
+# NOTE: Also testing varied arg syntax (`x`, `x::T`, `::T`).
+Salsa.@derived multi_method(db::AbstractComponent) = 1
+Salsa.@derived multi_method(db::AbstractComponent, arg) = arg
+Salsa.@derived multi_method(db::AbstractComponent, arg::Int) = 10
+Salsa.@derived multi_method(db::AbstractComponent, ::Symbol) = "!"
 
 Salsa.@component MultiMethodFunctions begin
 end
 @testset "multiple methods" begin
-    @test f(MultiMethodFunctions()) == 1
-    @test f(MultiMethodFunctions(), 2) == 10
-    @test f(MultiMethodFunctions(), "hi") == "hi"
+    @test multi_method(MultiMethodFunctions()) == 1
+    @test multi_method(MultiMethodFunctions(), 2) == 10
+    @test multi_method(MultiMethodFunctions(), "hi") == "hi"
+    @test multi_method(MultiMethodFunctions(), :bang) == "!"
 end
 
 # ----------------------------------


### PR DESCRIPTION
For example, this fixes method definitions like this:
```julia
Salsa.@derived f(db::AbstractComponent, ::String) = "!"
```

Fixes https://github.com/RelationalAI-oss/Salsa.jl/issues/9