### PR TITLE
Upstream changes from RelationalAI:

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Salsa"
 uuid = "1fbf2c77-44e2-4d5d-8131-0fa618a5c278"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Todd J. Green <todd.green@relational.ai>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/examples/SpreadsheetApp/Manifest.toml
+++ b/examples/SpreadsheetApp/Manifest.toml
@@ -9,12 +9,6 @@ git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.2.0"
 
-[[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "5a431d46abf2ef2a4d5d00bd0ae61f651cf854c8"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.10"
-
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -45,10 +39,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
-deps = ["DataStructures", "Markdown", "Random"]
-git-tree-sha1 = "07ee65e03e28ca88bc9a338a3726ae0c3efaa94b"
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.4"
+version = "0.5.5"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -56,12 +50,6 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
-[[OrderedCollections]]
-deps = ["Random", "Serialization", "Test"]
-git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.1.0"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]

--- a/src/DebugMode.jl
+++ b/src/DebugMode.jl
@@ -1,32 +1,78 @@
-module DebugMode
+module Debug
 
-export @debug_mode, DBG
+export @debug_mode, enable_debug, disable_debug, enable_trace_logging, disable_trace_logging
 
-# This file was modeled on the debug mode found in src/QueryEvaluator/trie_interface.jl
 
-DBG = true
+# `static_debug_mode` is a flag that enables/disables all debug mode checks
+const static_debug_mode = true
+
 
 """
-`debug_mode` is a flag that enables/disables the debug mode for the query evaluator
-"""
-const debug_mode = true
+@debug_mode expr...
 
-if debug_mode
-    """
-    Execute only in debug mode
-    """
-    macro debug_mode(instr)
-        esc(:(
-            if DBG != Nothing
-                $instr
+Execute `expr` only when static and runtime debug modes are enabled.
+"""
+macro debug_mode(instr)
+    if static_debug_mode
+        quote
+            if debug_enabled()
+                $(esc(instr))
             end
-        ))
-    end
-
-else
-    macro debug_mode(instr)
+        end
+    else
         :()
     end
 end
 
-end # module DebugMode
+if static_debug_mode
+    # Runtime debug mode controls
+    function enable_debug()
+        global _DBG = true
+    end
+    function disable_debug()
+        global _DBG = false
+    end
+    debug_enabled() = _DBG
+    _DBG = true
+
+
+    # Runtime trace logging controls
+    function enable_trace_logging()
+        global _tracing = true
+    end
+    function disable_trace_logging()
+        global _tracing = false
+    end
+    trace_logging_enabled() = _tracing
+    _tracing = false
+else
+    # Runtime Debugging is disabled.
+    _emit_debug_warning() = 
+        @warn """
+        Cannot enable runtime debug statements because debug is disabled statically.
+        To enable, reload Salsa after setting `static_debug_mode = true` in:
+        $(@__FILE__)
+        """
+
+    enable_debug() = _emit_debug_warning()
+    disable_debug() = _emit_debug_warning()
+    debug_enabled() = false
+
+    enable_trace_logging() = _emit_debug_warning()
+    disable_trace_logging() = _emit_debug_warning()
+    trace_logging_enabled() = false
+end
+
+macro dbg_log_trace(expr)
+    if static_debug_mode
+        quote
+            if trace_logging_enabled()
+                $(esc(expr))
+            end
+        end
+    else
+        :()
+    end
+end
+
+end # module Debug

--- a/src/inspect.jl
+++ b/src/inspect.jl
@@ -1,0 +1,125 @@
+module InspectSalsa
+using Salsa
+
+# Crude code to dump a .dot (graphviz) version of the Arroyo Node tree.
+# For debugging / illustration purposes - not intended to be reachable from production
+# code.
+function dump_graph(c::Salsa.AbstractComponent; module_boxes=false)
+    println(build_graph(c; module_boxes=module_boxes))
+end
+
+# There is no IdSet in julia, so we build our own from IdDict.
+# We need an IdSet to prevent comparing all the contents of the various maps, which is
+# expensive. We just want to compare via `===` which is what an IdDict does.
+# (Used the name _IdSet to indicate that this is internal only, and not a full-featured set)
+struct _IdSet{T}
+    d::IdDict{T,Nothing}  # Only using the Keys
+    _IdSet{T}() where T = new(IdDict{T,Nothing}())
+end
+Base.in(k, s::_IdSet) = haskey(s.d, k)
+Base.push!(s::_IdSet, k) = s.d[k] = nothing
+
+function build_graph(c::Salsa.AbstractComponent; module_boxes=false)
+    rt = Salsa.get_runtime(c)
+    io = IOBuffer()
+    println(io, """digraph G {""")
+    println(io, """edge [dir="back"];""")
+    seen = _IdSet{Any}()
+    modules_map = Dict{Module,Set}()
+    edges = Dict{Pair, Int}()
+    inputs = Dict{Any, String}()  # Note, there might be duplicate strings, Any must be the key
+
+    _build_graph(io, c, seen, modules_map, edges, inputs)
+
+    if module_boxes
+        for (m,keys) in modules_map
+            mname = nameof(m)
+            println(io, """subgraph cluster_$mname {""")
+            #println(io, """node [style=filled];""")
+            # First print non-input keys
+            println(io, """ $(join((repr(vertex_name(k)) for k in keys
+                                   if !haskey(inputs, k)), " ")) """);
+            begin  # Then print input keys all on the bottom
+                println(io, "{")
+                println(io, "rank=sink;")
+                println(io, """ $(join((repr(vertex_name(k)) for k in keys
+                                    if haskey(inputs, k)), " ")) """);
+                println(io, "}")
+            end
+            println(io, """ label = "Module `$mname`"; """)
+            println(io, """ fontsize = 25; """)
+            println(io, """ color=blue; """)
+            println(io, """}""")
+        end
+    end
+
+    if !module_boxes
+        println(io, "{")
+        println(io, "rank=sink;")
+    end
+    for (input_key, name) in inputs
+        println(io, """$(vertex_name(input_key)) [label="$name"]""")
+    end
+    if !module_boxes
+        println(io, "}")
+    end
+
+    max_count = maximum(values(edges))
+    maxwidth = 10
+    for ((a,b), count) in edges
+        normwidth = 1 + maxwidth * (count / max_count)
+        println(io, """ "$(vertex_name(a))" -> "$(vertex_name(b))"  [penwidth=$normwidth, weight=$normwidth]""")
+    end
+    @show max_count
+    println(io, "}")
+    return String(take!(io))
+end
+
+function _build_graph(io::IO, c::Salsa.AbstractComponent, seen::_IdSet, modules_map::Dict, edges::Dict, inputs::Dict)
+    rt = c.runtime
+    m = typeof(c).name.module
+    for fieldname in fieldnames(typeof(c))
+        f = getfield(c, fieldname)
+        if f in seen
+            continue
+        else
+            push!(seen, f)
+        end
+        if f isa Salsa.AbstractComponent
+            @show typeof(f)
+            _build_graph(io, f, seen, modules_map, edges, inputs)
+        elseif f isa Salsa.InputTypes
+            key = Salsa.InputKey(f)
+            inputs[key] = "@input: $(fieldname)"
+            push!(get!(modules_map, m, Set([])), key)
+        end
+    end
+
+    for (derived_key,derived_map) in rt.derived_function_maps
+        _build_graph(io, rt, derived_key, derived_map, seen, modules_map, edges)
+    end
+end
+
+function vertex_name(c::Any)::String
+    return "v$(objectid(c))"
+end
+
+function _build_graph(io, rt::Salsa.Runtime, derived_key::Salsa.DerivedKey{F,TT}, derived_map::Dict,
+     seen::_IdSet{Any}, modules_map::Dict{Module,Set}, edges::Dict{Pair, Int}) where {F,TT}
+    in(derived_key, seen) && return
+    push!(seen, derived_key)
+    m = methods(F.instance).mt.module
+    push!(get!(modules_map, m, Set([])), derived_key)
+    println(io, "$(vertex_name(derived_key)) [shape=rect,label=\"$(derived_key)\"]")
+    #println(io, "$(vertex_name(derived_key)) [label=\"$(derived_key)\"]")
+    for (k,v) in derived_map
+        for d in v.dependencies
+            edge = (derived_key) => (d.key) 
+            count = get!(edges, edge, 0) + 1
+            edges[edge] = count
+        end
+    end
+    #_build_graph(io, s.leaf_node, seen)
+end
+
+end # module

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -494,8 +494,21 @@ end
 
         # Now update the map and verify that the values do indeed update
         db.map[2] = 20
-        # NOTE: keys(Salsa.Map) is currently not supported
         @test sort(collect(values(db.map))) == [10, 20]
+    end
+
+    @testset "get!" begin
+        db = MapAggregatesDB()
+
+        get!(()->2, db.map, 1)
+        @test db.map[1] == 2
+
+        get!(()->3, db.map, 1)
+        @test db.map[1] == 2
+
+        delete!(db.map, 1)
+        get!(()->3, db.map, 1)
+        @test db.map[1] == 3
     end
 end
 


### PR DESCRIPTION
- Merge pull request #1449 from RelationalAI/nhd-Salsa-downstream
  Downstream from https://github.com/RelationalAI-oss/Salsa.jl
- Merge pull request #1485 from RelationalAI/compathelper/new_version/2…
  …020-03-28-00-14-03-879-1646924221
  CompatHelper: bump compat for "PProf" to "1.0"
- Merge pull request #1523 from RelationalAI/nhd-Salsa-display-dependen…
  …cy-graph
  Add Salsa inspect.jl to dump a dot graph / SVG from deps
  Add "SALSA_TRACE" logging for `get!()`; use `check_ENV` in Salsa.
- Merge pull request #1590 from RelationalAI/nhd-Salsa-downstream
  Downstream RelationalAI-oss/Salsa.jl#10
- Merge pull request #1628 from RelationalAI/nhd-salsa-tracing-fix
  Fix up Salsa trace to not dump the whole Input map in log.

---------

Highlights:

## Add `inspect.jl`:

Adds functions to build a `dot` graph from a Salsa component/runtime, to allow displaying and understanding the dependency graph.

For example, if you load the Salsa SpreadsheetApp example and build up a Salsa state:
```julia
(Delve) pkg> activate packages/Salsa/examples/SpreadsheetApp/
 Activating environment at `~/Documents/work/rai/raicode2/packages/Salsa/examples/SpreadsheetApp/Project.toml`

julia> include("packages/Salsa/examples/SpreadsheetApp/src/SpreadsheetApp.jl")
WARNING: replacing module SpreadsheetApp.
[ Info: Precompiling TerminalMenus [dc548174-15c3-5faf-af27-7997cfbde655]
Main.SpreadsheetApp

julia> ss = SpreadsheetApp.main()

...

──────────────────────────────
 Cell Text:

       A     B     C     D     E
 1 |    3|    2|  2.0[     ]     |
 2 |     |  7.0|     |     |     |
 3 |     |     |     |     |     |
 4 |     |     |     |     |     |
 5 |     |     |     |     |     |

julia>
```
Then you can build a `dot` graph of the current dependency graph in Salsa (and convert it to a png or svg if you have graphviz installed):
```julia
julia> write("ss.dot", Salsa.InspectSalsa.build_graph(ss, module_boxes=false)); run(`dot -Tsvg ss.dot -o ss.svg`)
```
For example, here's the .png for the SpreadsheetApp:
![ss](https://user-images.githubusercontent.com/44379820/78401318-767b7c00-75c6-11ea-82b4-20e41e07a4a0.png)


The most interesting part of this graph is actually the recursive call from `cell_value()` to itself, which is unfortunately easy to miss, but that's what builds the execution graph that flows data between the cells. We might want to provide other modes that allow separating out the _values_ in the calls, in order to see that unrolled execution graph, but I could imagine it would be a bit unwieldy.


## Improve Salsa Tracing:

Salsa tracing is no longer controlled by an environment variable (`ENV["SALSA_TRACE"]`) and instead now controlled with these toggle functions:
- Salsa.Debug.enable_trace_logging()
- Salsa.Debug.disable_trace_logging()

For example, with the new logging:

```julia
julia> Salsa.Debug.enable_trace_logging()
true

julia> @testset "get!" begin
           db = MapAggregatesDB()
           get!(()->2, db.map, 1)
           @test db.map[1] == 2
           get!(()->3, db.map, 1)
           @test db.map[1] == 2
           delete!(db.map, 1)
           get!(()->3, db.map, 1)
           @test db.map[1] == 3
       end
[ Info: Setting input on InputMap{Int64,Int64}(): 1 => 2
[ Info: Deleting input on InputMap(1 => 2): 1
[ Info: Setting input on InputMap{Int64,Int64}(): 1 => 3
Test Summary: | Pass  Total
get!          |    3      3
Test.DefaultTestSet("get!", Any[], 3, false)
```