### PR TITLE
Upstream from RelationalAI: re-enable pretty-printed stacks; performance tuning; add simple microbenchmark

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Nathan Daly <nhdaly@gmail.com>", "Todd J. Green <todd.green@relation
 version = "1.1.0"
 
 [deps]
+ExceptionUnwrapping = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]

--- a/bench/README.md
+++ b/bench/README.md
@@ -2,6 +2,11 @@
 
 This directory contains some simple benchmarks for the Salsa package.
 
+Currently this just contains very simple microbenchmarks that repeatedly set a value
+and then read from downstream derived functions that depend on the value.
+These microbenchmarks are useful for improving the base Salsa performance of setting
+and retrieving values in the cache.
+
 ## Generic Benchmarks
 
 All benchmarks in this directory should be kept generic so that users can run them with

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,19 @@
+# Salsa Benchmarks
+
+This directory contains some simple benchmarks for the Salsa package.
+
+## Generic Benchmarks
+
+All benchmarks in this directory should be kept generic so that users can run them with
+whatever kind of custom Runtime (with Storage and Config) that they might use in their
+system. It's okay to default to the default `Runtime()`.
+
+You can achieve this either by having the user pass in a Runtime object, or by having
+them pass in a function to construct a new Runtime instance if you want the construction
+to be part of what's measured, etc.
+
+## run()
+
+As a convention it's also nice to provide a single `run()` function for any benchmarks here,
+so that if you just want to use all the standard configurations, you can run all the
+benchmarks with a single function call.

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -7,6 +7,10 @@ using BenchmarkTools
     in1(rt, x) + 1
 end
 
+@derived function d2(rt, x::Int)
+    d1(rt, x) + 1
+end
+
 function simple_bench(rt=Runtime(); N, iters)
     rt = Runtime()
     for j in 1:iters
@@ -15,7 +19,7 @@ function simple_bench(rt=Runtime(); N, iters)
             set_in1!(rt, i, i+j)
         end
         for i in 1:N
-            d1(rt, i)
+            d2(rt, i)
         end
     end
 end
@@ -29,7 +33,7 @@ function parallel_bench(rt::Runtime; N, iters)
         end
         for i in 1:N
             Threads.@spawn begin
-                d1(rt, i)
+                d2(rt, i)
             end
         end
     end

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -4,11 +4,11 @@ using BenchmarkTools
 @declare_input in1(rt, ::Int)::Int
 
 @derived function d1(rt, x::Int)
-    in1(rt, x) + 1
+    return in1(rt, x) + 1
 end
 
 @derived function d2(rt, x::Int)
-    d1(rt, x) + 1
+    return d1(rt, x) + 1
 end
 
 function simple_bench(rt::Runtime; N, iters)

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -1,0 +1,39 @@
+using Salsa
+using BenchmarkTools
+
+@declare_input in1(rt, ::Int)::Int
+
+@derived function d1(rt, x::Int)
+    in1(rt, x) + 1
+end
+
+function simple_bench(rt=Runtime(); N=10, iters=100)
+    rt = Runtime()
+    for j in 1:iters
+        for i in 1:N
+            set_in1!(rt, i, i+j)
+        end
+        for i in 1:N
+            d1(rt, i)
+        end
+    end
+end
+
+function parallel_bench(rt=Runtime(); N=10, iters=100)
+    rt = Runtime()
+    for j in 1:iters
+        for i in 1:N
+            set_in1!(rt, i, i+j)
+        end
+        for i in 1:N
+            Threads.@spawn begin
+                d1(rt, i)
+            end
+        end
+    end
+end
+
+function run()
+    @btime simple_bench()
+    @btime parallel_bench()
+end

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -11,7 +11,7 @@ end
     d1(rt, x) + 1
 end
 
-function simple_bench(rt=Runtime(); N, iters)
+function simple_bench(rt::Runtime; N, iters)
     rt = Runtime()
     for j in 1:iters
         Salsa.new_epoch!(rt)
@@ -31,7 +31,7 @@ function parallel_bench(rt::Runtime; N, iters)
         for i in 1:N
             set_in1!(rt, i, i+j)
         end
-        for i in 1:N
+        @sync for i in 1:N
             Threads.@spawn begin
                 d2(rt, i)
             end
@@ -39,7 +39,7 @@ function parallel_bench(rt::Runtime; N, iters)
     end
 end
 
-function run()
-    @btime simple_bench()
-    @btime parallel_bench()
+function run(; N, iters)
+    @btime simple_bench(rt; N=$N, iters=$iters) setup=(rt=Runtime())
+    @btime parallel_bench(rt; N=$N, iters=$iters) setup=(rt=Runtime())
 end

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -37,6 +37,7 @@ function parallel_bench(rt::Runtime; N, iters)
     end
 end
 
+# Run all the above benchmarks and report the results to stdout
 function run(; N, iters)
     @btime simple_bench(rt; N=$N, iters=$iters) setup=(rt=Runtime())
     @btime parallel_bench(rt; N=$N, iters=$iters) setup=(rt=Runtime())

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -7,9 +7,10 @@ using BenchmarkTools
     in1(rt, x) + 1
 end
 
-function simple_bench(rt=Runtime(); N=10, iters=100)
+function simple_bench(rt=Runtime(); N, iters)
     rt = Runtime()
     for j in 1:iters
+        Salsa.new_epoch!(rt)
         for i in 1:N
             set_in1!(rt, i, i+j)
         end
@@ -19,9 +20,10 @@ function simple_bench(rt=Runtime(); N=10, iters=100)
     end
 end
 
-function parallel_bench(rt=Runtime(); N=10, iters=100)
+function parallel_bench(rt::Runtime; N, iters)
     rt = Runtime()
     for j in 1:iters
+        Salsa.new_epoch!(rt)
         for i in 1:N
             set_in1!(rt, i, i+j)
         end

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -12,7 +12,6 @@ end
 end
 
 function simple_bench(rt::Runtime; N, iters)
-    rt = Runtime()
     for j in 1:iters
         Salsa.new_epoch!(rt)
         for i in 1:N
@@ -25,7 +24,6 @@ function simple_bench(rt::Runtime; N, iters)
 end
 
 function parallel_bench(rt::Runtime; N, iters)
-    rt = Runtime()
     for j in 1:iters
         Salsa.new_epoch!(rt)
         for i in 1:N

--- a/src/Debug.jl
+++ b/src/Debug.jl
@@ -4,7 +4,12 @@ export @debug_mode, enable_debug, disable_debug, enable_trace_logging, disable_t
 
 
 # `static_debug_mode` is a flag that enables/disables all debug mode checks
-const static_debug_mode = true
+# This defaults to true, but you can disable it either by editing this file, or by
+# setting this environment variable when compiling this package. This is useful
+# for performance benchmarking and in well-tested production environments.
+# e.g. SALSA_STATIC_DEBUG=false
+
+const static_debug_mode = parse(Bool, get(ENV, "SALSA_STATIC_DEBUG", "true"))
 
 
 """

--- a/src/Debug.jl
+++ b/src/Debug.jl
@@ -8,7 +8,6 @@ export @debug_mode, enable_debug, disable_debug, enable_trace_logging, disable_t
 # setting this environment variable when compiling this package. This is useful
 # for performance benchmarking and in well-tested production environments.
 # e.g. SALSA_STATIC_DEBUG=false
-
 const static_debug_mode = parse(Bool, get(ENV, "SALSA_STATIC_DEBUG", "true"))
 
 

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -678,12 +678,7 @@ logic, that reuses the previously computed value to compute the next value more 
 """
 function previous_output(rt::Salsa._TracingRuntime)
     dependency_key = get_trace(rt.immediate_dependencies_id).call_stack.dp
-    return _previous_output_internal(rt, dependency_key)
-    # if maybe_previous_value === nothing
-    #     return nothing
-    # else
-    #     return _unwrap_salsa_value(rt, maybe_previous_value)
-    # end
+    return _unwrap_salsa_value(rt, _previous_output_internal(rt, dependency_key))
 end
 
 function previous_output(::Salsa._TopLevelRuntime)

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -820,6 +820,7 @@ function _safe_deleter_body(::Salsa._TracingRuntime, key)
     error("Attempted impure operation in a derived function!: delete_input!(rt, $key)")
 end
 
+# This function is for use by versioned storage that supports epochs. Not needed for DefaultStorage.
 function new_epoch! end
 
 # Provide Storage-major view on Runtime types for ease of implementing Storage backends.

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -393,7 +393,7 @@ function get_free_trace_id()::TraceId
     trace_freelist = tls_trace_freelist()
     trace_pool = tls_trace_pool()
     if isempty(trace_freelist)
-        @debug_mode @info "DOUBLING MINISALSA TRACE POOL ON THREAD $(Threads.threadid())"
+        @debug_mode @info "DOUBLING SALSA TRACE POOL ON THREAD $(Threads.threadid())"
         old_size = length(tls_trace_pool())
         num_new_traces = old_size # Double the pool
         @debug_mode @assert num_new_traces > 0

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -820,6 +820,7 @@ function _safe_deleter_body(::Salsa._TracingRuntime, key)
     error("Attempted impure operation in a derived function!: delete_input!(rt, $key)")
 end
 
+function new_epoch! end
 
 # Provide Storage-major view on Runtime types for ease of implementing Storage backends.
 const RuntimeWithStorage{ST,CT} = Runtime{CT,ST}

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -828,6 +828,8 @@ const RuntimeWithStorage{ST,CT} = Runtime{CT,ST}
 const _TopLevelRuntimeWithStorage{ST,CT} = _TopLevelRuntime{CT,ST}
 const _TracingRuntimeWithStorage{ST,CT} = _TracingRuntime{CT,ST}
 
+# Default context manual storage
+RuntimeWithStorage{ST}(st = ST()) where {ST} = Runtime{EmptyContext,ST}(EmptyContext(), st)
 
 include("default_storage.jl")
 using ._DefaultSalsaStorage: DefaultStorage, DefaultRuntime

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -9,7 +9,9 @@ end Salsa
 # This is the entirety of the Salsa API: Users create inputs and derived functions, and
 # access them through a Runtime instance.
 export @derived, @declare_input, Runtime, SalsaWrappedException
+
 import MacroTools
+using Base: @lock
 
 include("Debug.jl")
 using .Debug
@@ -226,15 +228,12 @@ mutable struct TraceOfDependencyKeys
 end
 
 function push_key!(trace::TraceOfDependencyKeys, depkey)
-    try
-        lock(trace.lock)
+    @lock trace.lock begin
         # Performance Optimization: De-duplicating Derived Function Traces
         if depkey ∉ trace.seen_deps
             push!(trace.ordered_deps, depkey)
             push!(trace.seen_deps, depkey)
         end
-    finally
-        unlock(trace.lock)
     end
     return nothing
 end

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -656,12 +656,12 @@ logic, that reuses the previously computed value to compute the next value more 
 """
 function previous_output(rt::Salsa._TracingRuntime)
     dependency_key = get_trace(rt.immediate_dependencies_id).call_stack.dp
-    maybe_previous_value = _previous_output_internal(rt, dependency_key)
-    if maybe_previous_value === nothing
-        return nothing
-    else
-        return _unwrap_salsa_value(rt, maybe_previous_value)
-    end
+    return _previous_output_internal(rt, dependency_key)
+    # if maybe_previous_value === nothing
+    #     return nothing
+    # else
+    #     return _unwrap_salsa_value(rt, maybe_previous_value)
+    # end
 end
 
 function previous_output(::Salsa._TopLevelRuntime)

--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -606,7 +606,7 @@ function invoke_user_function end
 
 
 # We @nospecialize the dependency key argument here for compiler performance.
-function memoized_lookup(rt::Runtime, @nospecialize(dependency_key::DependencyKey))
+function memoized_lookup(rt::Runtime, dependency_key::DependencyKey)
     # NOTE: It is important that the tracing happens around all internal computations for
     # derived functions and input functions, as we want to be sure we record _all_
     # dependencies, even those where the result is already cached.

--- a/src/default_storage.jl
+++ b/src/default_storage.jl
@@ -390,7 +390,7 @@ function Salsa.delete_input!(
     end
 end
 
-function Salsa.new_epoch!(runtime::Salsa.Runtime{DefaultStorage})
+function Salsa.new_epoch!(runtime::Salsa.RuntimeWithStorage{DefaultStorage})
 end
 
 end  # module

--- a/src/default_storage.jl
+++ b/src/default_storage.jl
@@ -390,4 +390,7 @@ function Salsa.delete_input!(
     end
 end
 
+function Salsa.new_epoch!(runtime::Salsa.Runtime{DefaultStorage})
+end
+
 end  # module

--- a/src/default_storage.jl
+++ b/src/default_storage.jl
@@ -185,6 +185,9 @@ function Salsa._memoized_lookup_internal(
                 unlock(storage.lock)
                 lock_held = false
 
+                # storage.current_revision should be monotonically increasing.
+                @debug_mode @assert (storage.current_revision >= existing_value.verified_at)
+
                 # NOTE: There is no race condition possible here, despite that the storage
                 # isn't locked, because all code that might bump `current_revision`
                 # (`set_input!` and `delete_input!`) first asserts that there are no active

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -2,7 +2,7 @@
 
 using Test
 using Salsa
-using Salsa: Runtime, InputKey, DependencyKey
+using Salsa: Runtime, InputKey, DependencyKey, SalsaWrappedException
 
 # NOTE: This test file expects `new_test_rt([ctx,])` to be defined before it is called,
 # which is used to construct new Runtime() instances for the tests. This is so that
@@ -32,7 +32,7 @@ using Salsa: Runtime, InputKey, DependencyKey
 
 
     s = new_test_rt()
-    @test_throws KeyError mymap(s, "hello", 2)
+    @test_throws SalsaWrappedException{KeyError} mymap(s, "hello", 2)
     set_mymap!(s, "hello", 2, 10)
     @test mymap(s, "hello", 2) === 10
 
@@ -197,7 +197,7 @@ end
     # Setting a value that will cause square_root() to throw an Exception
     Salsa.new_epoch!(db)
     ErrorHandlingTests.set_val!(db, -1)
-    @test_throws DomainError ErrorHandlingTests.square_root(db)
+    @test_throws SalsaWrappedException{DomainError} ErrorHandlingTests.square_root(db)
 
     # Now test that it's recovered gracefully from the error, and we can still use the DB
     Salsa.new_epoch!(db)
@@ -214,7 +214,7 @@ end
     ErrorHandlingTests.set_val!(db, -1)
     ErrorHandlingTests.set_map!(db, 1, 2)
     # Attempts 2 * sqrt(-1), and throws an error
-    @test_throws DomainError ErrorHandlingTests.val_times_sqrt(db, 1)
+    @test_throws SalsaWrappedException{DomainError} ErrorHandlingTests.val_times_sqrt(db, 1)
 
     # Now test that it's recovered gracefully from the error, and we can still use the DB
     Salsa.new_epoch!(db)
@@ -224,8 +224,8 @@ end
 
     # Now check that we also recover from KeyErrors when reading from a map:
     Salsa.new_epoch!(db)
-    # Throw error:
-    @test_throws KeyError ErrorHandlingTests.val_times_sqrt(db, 100)  # No key 100
+    # Throw error (No key 100):
+    @test_throws SalsaWrappedException{KeyError} ErrorHandlingTests.val_times_sqrt(db, 100)
     # But this call still works:
     @test ErrorHandlingTests.val_times_sqrt(db, 1) == 2  # 2 * sqrt(1)
 end
@@ -257,7 +257,7 @@ end
     # Delete student only from student_grade but leave in all_student_ids (a programming error)
     Salsa.new_epoch!(rt)
     delete_student_grade!(rt, 2)
-    @test_throws KeyError average_grade(rt)
+    @test_throws SalsaWrappedException{KeyError} average_grade(rt)
 end
 
 struct LoggingContext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,15 @@
+module SalsaTest
+
 using Test
+using Salsa
+
+# The Salsa.jl test is configurable to run with arbitrary Runtime instances, by
+# providing your own implementation of this function before running `"test/Salsa.jl"`.
+new_test_rt() = Runtime()
+new_test_rt(ctx::Context) where Context = Runtime{Context}(ctx)
 
 @testset "Salsa.jl" begin
     include("Salsa.jl")
 end
+
+end # SalsaTest


### PR DESCRIPTION
Upstream these commits from RelationalAI repo:

- 4386dce Switch RAI from MiniSalsa back to Salsa! :D
- 3558fd3 Fix merge conflict: move MiniSalsa changes to packages/Salsa
- 5030d0f Implement Salsa.previous_output with maintenance in RAI backend
- c06c2b5 Update src/default_storage.jl
- 4aeecd4 Apply suggestions from code review
- 9be0087 Add simple Salsa benchmarks
- b807f8d Add simple Salsa benchmarks for DefaultStorage and RAI storage
- 67ddd4d Add a second derived function layer
- 426f31d Fix Salsa bench: parallel bench and open-source runner.
- ca02f42 Fix RAI benchmarks. Now all the Salsa benchmarks run
- 758af5e Make Salsa static debug flag configurable. Disable for benchmarks.
- 09b3ddf 🤦 Fix Salsa benchmarks: _actually_ use the provided Runtime arg!
- b103439 Add documentation for Salsa benchmarks.
- b922614 Add explanation to the Salsa microbenchmarks README
- 2970af8 Performance tweaks
- 931f388 Use `Base.@lock` macro, instead of `lock(f,l)`
- 7e1224d Make the Salsa tests configurable in the Runtime they run with, so we
- 6fe3e8c Apply suggestions from code review
- f59d9b9 Use ExceptionUnwrapping.jl to re-enable nice Salsa summary stack traces (#1479)
- 95fdf99 Add an assert to Salsa to catch malformed Salsa storage

Fixes #1 