### PR TITLE
Fix bug in Salsa stack trace printing: off-by-one

### DIFF
--- a/src/Salsa.jl
+++ b/src/Salsa.jl
@@ -187,8 +187,8 @@ end
 function Base.collect(stack::SalsaStackFrame)
     out = DependencyKey[stack.dp]
     while stack.next !== nothing
-        push!(out, stack.dp)
         stack = stack.next
+        push!(out, stack.dp)
     end
     return out
 end


### PR DESCRIPTION
Fixes #25 

Now this prints correctly:
```julia
julia> using Salsa

julia> @derived f(rt, x) = g(rt, x)
f (generic function with 1 method)

julia> @derived g(rt, x) = h(rt, x)
g (generic function with 1 method)

julia> @derived h(rt, _) = error("OH NO")
h (generic function with 1 method)

julia> f(Runtime(), 1)
ERROR: SalsaWrappedException: Error encountered while executing Salsa derived function:
OH NO

------ Salsa Trace -----------------
[1] @derived f(::Runtime, 1::Any)
[2] @derived g(::Runtime, 1::Any)
[3] @derived h(::Runtime, 1::Any)
------------------------------------

Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] %%__user_h(::Salsa._TracingRuntime{Salsa.EmptyContext,Salsa._DefaultSalsaStorage.DefaultStorage}, ::Int64) at ./REPL[16]:1
 [3] invoke_user_function(::Salsa._TracingRuntime{Salsa.EmptyContext,Salsa._DefaultSalsaStorage.DefaultStorage}, ::Salsa.DerivedKey{typeof(h),Tuple{Any}}, ::Int64) at /Users/daly/julia-dev/Salsa/src/Salsa.jl:612
...
```