### PR TITLE
Fix up Salsa.Inspect.build_graph after DefaultStorage perf changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Salsa"
 uuid = "1fbf2c77-44e2-4d5d-8131-0fa618a5c278"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Todd J. Green <todd.green@relational.ai>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 ExceptionUnwrapping = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"


### PR DESCRIPTION
The changes in #27 changed the way we represent keys, and I forgot to update the Inspect code to still be able to print a graph.

This fixes the Inspect graph building to still work with the new representation in default_storage.jl.