### PR TITLE
Fix where clauses for Derived Functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Salsa"
 uuid = "1fbf2c77-44e2-4d5d-8131-0fa618a5c278"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Todd J. Green <todd.green@relational.ai>"]
-version = "2.1.1"
+version = "2.2.0"
 
 [deps]
 ExceptionUnwrapping = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -168,8 +168,7 @@ end
 
         # Derived function with typed argument
         Salsa.@derived where_func_T(db, ::Type{T}) where T = sizeof(T)
-        # TODO: This is broken because typeof(Int) is DataType, but DataType is not <: Type
-        @test_broken where_func_T(Runtime(), Int) == 8
+        @test where_func_T(Runtime(), Int) == 8
 
         # Where clauses on inputs aren't yet supported. Do they even make sense?
         #Salsa.@declare_input where_input(db, ::Type{T})::T where T

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -161,9 +161,18 @@ end
 
 @testset "macro usage corner cases" begin
     @testset "where clauses" begin
-        #Salsa.@declare_input where_input(db, ::Type{T})::T where T
+        # A simple derived function with a where clause
+        Salsa.@derived where_func_x(db, x::T) where T = sizeof(T)
+        @test where_func_x(Runtime(), 0) == 8
+        @test where_func_x(Runtime(), Int8(0)) == 1
 
-        Salsa.@derived where_func(db, ::Type{T}) where T = sizeof(T)
+        # Derived function with typed argument
+        Salsa.@derived where_func_T(db, ::Type{T}) where T = sizeof(T)
+        # TODO: This is broken because typeof(Int) is DataType, but DataType is not <: Type
+        @test_broken where_func_T(Runtime(), Int) == 8
+
+        # Where clauses on inputs aren't yet supported. Do they even make sense?
+        #Salsa.@declare_input where_input(db, ::Type{T})::T where T
     end
 end
 

--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -159,6 +159,14 @@ end
     @test x(rt, 1, "hi") == "ho"
 end
 
+@testset "macro usage corner cases" begin
+    @testset "where clauses" begin
+        #Salsa.@declare_input where_input(db, ::Type{T})::T where T
+
+        Salsa.@derived where_func(db, ::Type{T}) where T = sizeof(T)
+    end
+end
+
 @testset "inputs and derived functions support docstrings" begin
     @test @macroexpand(begin
         """ My Input """


### PR DESCRIPTION
Fixes https://github.com/RelationalAI-oss/Salsa.jl/issues/11

I got the idea from Memoization.jl, that the key type constants we were evaluating in the macro (at parse time) to save runtime work, could also be performed at compile time by moving them to global scope. So that's what this PR does. :)

I defined them as `@inline` functions, rather than `const`s so that we can also support `@derived` functions defined inside of a scope! :)