### PR TITLE
Add support for default values for Salsa derived functions

### DIFF
--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -173,6 +173,21 @@ end
         # Where clauses on inputs aren't yet supported. Do they even make sense?
         #Salsa.@declare_input where_input(db, ::Type{T})::T where T
     end
+    @testset "default values - derived functions" begin
+        @declare_input source_text(rt, name::String)::String
+        @derived default_source(rt, name::String="stdlib") = source_text(rt, name)
+
+        rt = Runtime()
+        set_source_text!(rt, "stdlib", "hello")
+        @test default_source(rt) == default_source(rt, "stdlib") == "hello"
+    end
+    # Default values are not supported for inputs.
+    #@testset "default values - inputs" begin
+    #    @declare_input currency_value(rt, country="US")::Float64
+    #
+    #    rt = Runtime()
+    #    set_currency_value!(rt, 1.0)
+    #end
 end
 
 @testset "inputs and derived functions support docstrings" begin


### PR DESCRIPTION
Fixes #12.

Follow up to #31.

Add support for default values for Salsa derived functions.

I didn't add this to inputs, because the syntax for set/delete is ambiguous. :(