### PR TITLE
avoid potential compiler-internal error

### DIFF
--- a/test/Salsa.jl
+++ b/test/Salsa.jl
@@ -383,7 +383,9 @@ end
 
     rt = new_test_rt()
     # Initialize the inputs
-    I = 1000  # Number of concurrent tasks scheduled
+    # XXX DO NOT make `I` too big, e.g. `I = 1000`, otherwise `_names::NTuple{I,Symbol}` may
+    # cause the internal compiler error (see https://github.com/JuliaLang/julia/issues/38364)
+    I = 100 # Number of concurrent tasks scheduled
     _names = Tuple(Symbol("range$i") for i in 1:I)
     N = 10_000
 


### PR DESCRIPTION
It's generally better to avoid constructing excessively large tuple since it may cause the internal error in the compiler (see JuliaLang/julia/#38364). In particular, it turns out that this line can cause the stack-overflow error in the optimizer (xref: JuliaLang/julia#48913):
<https://github.com/RelationalAI-oss/Salsa.jl/blob/e8029cc8401734e5bd26e142b653ed368499f2c5/test/Salsa.jl#L386-L387>

This commit decreases the value of `I`, because our compiler does not support a code containing such a big tuple.