### PR TITLE
perf: don't let wide traces poison the trace pool

### DIFF
--- a/src/trace.jl
+++ b/src/trace.jl
@@ -9,6 +9,11 @@
 # potential downside is losing some ordering information if part of the function is serial
 # and part is parallel.
 #
+# Initial capacity of a trace's dependency containers. (Oversized traces are
+# reset to `TRACE_CONTAINER_SHRINK_THRESHOLD` capacity on release instead; see
+# `empty_trace!`.)
+const TRACE_INITIAL_CAPACITY = 30
+
 # NOTE: This is a mutable struct to allow us to modify the call_stack. This is fine because
 # it's not going to be isbits anyway due to all of the Vectors, Sets, and Locks, it
 # contains, and we are going to keep these in the trace pool (see explanation below).
@@ -44,13 +49,9 @@ mutable struct TraceOfDependencyKeys
         # Pre-allocate all traces to be non-empty, to minimize allocations at runtime.
         # These traces are all constructed once ahead of time in the per-thread trace pools,
         # so this initialization is only done once during Module __init__().
-        #
-        # TODO: Tune this. Too big wastes RAM (though, it's fixed cost up front).
-        #       Current size, 30, adds about 1MiB, which seems not bad.
-        N = 30
         return new(
-            sizehint!(Vector{DependencyKey}(), N),
-            sizehint!(Set{DependencyKey}(), N),
+            sizehint!(Vector{DependencyKey}(), TRACE_INITIAL_CAPACITY),
+            sizehint!(Set{DependencyKey}(), TRACE_INITIAL_CAPACITY),
             Base.ReentrantLock(),
             nothing,
             true,

--- a/src/trace_pool.jl
+++ b/src/trace_pool.jl
@@ -137,7 +137,52 @@ function release_trace_id(id::TraceId)
     return nothing
 end
 
+# Traces that recorded more than this many dependencies get fresh containers on
+# release instead of being cleared in place. Pooled containers keep their
+# high-water-mark capacity forever, and the replacement matters for different
+# reasons per container:
+#   - `seen_deps` (Set): `empty!` on a Dict/Set costs O(capacity) even when it
+#     holds no elements (every slot is swept unconditionally), so an oversized
+#     Set would tax every later release that reuses this pooled trace.
+#   - `ordered_deps` (Vector): `empty!` on a Vector is O(length), never
+#     O(capacity), so clearing stays cheap — replacing it only releases the
+#     retained high-water-mark memory.
+# Fresh containers are also cheaper than shrinking in place
+# (`sizehint!(c, n; shrink=true)` pays O(old capacity) on the release path to
+# rehash/copy the old table).
+const TRACE_CONTAINER_SHRINK_THRESHOLD = 256
+
 function empty_trace!(trace::TraceOfDependencyKeys)
-    empty!(trace.ordered_deps)
-    empty!(trace.seen_deps)
+    # Locked to guard against a straggler task racing `push_key!` against this
+    # release. Spawning tasks that outlive their derived function is documented
+    # as unsupported (see `collect_trace`) but cannot be detected; without the
+    # lock, such a task could observe one old and one new container around the
+    # replacement below, leaving `seen_deps` and `ordered_deps` inconsistent for
+    # the trace's next user. Uncontended in correct usage, so this is cheap.
+    @lock trace.lock begin
+        # The dependency-array swap optimization in `_memoized_lookup_internal`
+        # can leave `ordered_deps` empty while `seen_deps` still holds every
+        # recorded key, so both containers must be considered.
+        n = max(length(trace.ordered_deps), length(trace.seen_deps))
+        if n == 0
+            # Nothing to clear. This is the hot path: verification-only lookups
+            # (`should_trace` off) release their trace untouched, and must not
+            # pay the O(capacity) Set sweep for whatever used this trace before.
+        elseif n > TRACE_CONTAINER_SHRINK_THRESHOLD
+            # Reset to the threshold capacity, not TRACE_INITIAL_CAPACITY: the
+            # in-place branch below already tolerates containers of this size,
+            # and a derived function that is consistently wide would otherwise
+            # pay Vector reallocs and Set rehashes on every run to regrow from
+            # a tiny container (rehashing is especially costly here because
+            # `hash(::DependencyKey)` allocates).
+            trace.ordered_deps =
+                sizehint!(Vector{DependencyKey}(), TRACE_CONTAINER_SHRINK_THRESHOLD)
+            trace.seen_deps =
+                sizehint!(Set{DependencyKey}(), TRACE_CONTAINER_SHRINK_THRESHOLD)
+        else
+            empty!(trace.ordered_deps)
+            empty!(trace.seen_deps)
+        end
+    end
+    return
 end

--- a/test/test_salsa.jl
+++ b/test/test_salsa.jl
@@ -726,3 +726,44 @@ end
     @test overrideable(rt, 2) == 777
     @test call_count[] == 1  # No extra lazy calls
 end
+
+# NOTE: This test is testing internal aspects of the package, not the public API.
+@testitem "Trace pool: wide traces do not permanently retain capacity" setup=[SalsaSetup] begin
+    using .SalsaSetup: new_test_rt
+
+    @declare_input entry(rt, i::Int)::Int
+
+    @derived function wide_sum(rt, n::Int)::Int
+        s = 0
+        for i in 1:n
+            s += entry(rt, i)
+        end
+        return s
+    end
+
+    rt = new_test_rt()
+
+    n = 4 * Salsa.TRACE_CONTAINER_SHRINK_THRESHOLD
+    for i in 1:n
+        set_entry!(rt, i, i)
+    end
+
+    @test wide_sum(rt, n) == sum(1:n)
+
+    # Releasing the wide trace must not leave oversized containers in the pool.
+    # Pooled containers otherwise keep their high-water-mark capacity forever,
+    # and clearing a Dict/Set costs O(capacity) even when it is empty — so a
+    # single wide derived function would tax every later lookup that reuses its
+    # pooled trace.
+    max_slots = maximum(
+        length(tr.seen_deps.dict.slots)
+        for pool in Salsa.g_threadlocal_trace_pools for tr in pool
+    )
+    @test max_slots <= 4 * Salsa.TRACE_CONTAINER_SHRINK_THRESHOLD
+
+    # The replaced containers must still trace correctly: invalidate one input
+    # and verify the wide function recomputes through the same pooled traces.
+    Salsa.new_epoch!(rt)
+    set_entry!(rt, 1, 101)
+    @test wide_sum(rt, n) == sum(1:n) + 100
+end


### PR DESCRIPTION
Pooled dependency traces kept their high-water-mark capacity forever, and clearing a Dict/Set costs O(capacity) even when it holds no elements (boxed keys are unset one by one). A single wide derived function (hundreds of dependencies) therefore inflated a pooled trace permanently, and because the freelist is LIFO, exactly that trace was reused for every subsequent memoized_lookup — including pure verification lookups that trace nothing. In a large workspace this put ~3.3us of pure clearing work on the ~4us lookup fast path, dominating dependency re-verification after every input change.

On release, skip clearing entirely when the trace recorded nothing (the verification fast path), and replace the containers with fresh small ones when it recorded more than TRACE_CONTAINER_SHRINK_THRESHOLD dependencies. Verified fast-path lookups drop from ~3.8us to ~0.5us.