### PR TITLE
perf: make the verification walk allocation-free

### DIFF
--- a/src/default_storage.jl
+++ b/src/default_storage.jl
@@ -332,13 +332,29 @@ end
 
 # A `value` is still valid if none of its dependencies have changed.
 function still_valid(runtime, value)
+    storage = Salsa.storage(runtime)
     for depkey in value.dependencies
-        dep_changed_at = key_changed_at(runtime, depkey)
+        dep_changed_at = _key_changed_at(runtime, storage, depkey)
         if dep_changed_at > value.verified_at
             return false
         end
     end # for
     return true
+end
+
+# Public entry point; unused internally (callers thread `storage` via `_key_changed_at`).
+key_changed_at(runtime, key::DependencyKey) = _key_changed_at(runtime, Salsa.storage(runtime), key)
+
+# Manual union split: with `key` narrowed by `isa`, each call below resolves
+# to exactly one (@nospecialize'd) method, so the isbits runtime is passed
+# unboxed — a dynamic dispatch here would box it (and the returned Int) once
+# per dependency edge, tens of MB of garbage per whole-graph verification.
+Base.@inline function _key_changed_at(runtime, storage::DefaultStorage, key::DependencyKey)::Revision
+    if key isa InputKey
+        return _input_changed_at(runtime, storage, key)
+    else
+        return _derived_changed_at(runtime, storage, key)
+    end
 end
 
 # Verification fast path: pure verification needs no trace bookkeeping (deps
@@ -347,25 +363,33 @@ end
 # holds it >= 1, so `current_revision` is stable here — the same invariant the
 # slow path relies on). One lock + one probe per node; anything that needs
 # recomputation (or a lazy-input fill) falls back to the full traced
-# `memoized_lookup`.
-function key_changed_at(runtime, key::InputKey)
-    storage = Salsa.storage(runtime)
+# `memoized_lookup`. `key` is deliberately unspecialized: one compiled
+# instance regardless of the key's function/argument types.
+function _input_changed_at(runtime, storage::DefaultStorage, @nospecialize(key::InputKey))::Revision
     v = @lock storage.lock get(storage.inputs_map, key, nothing)
     v === nothing && return _changed_at(memoized_lookup(runtime, key))
     return v.changed_at
 end
 
-function key_changed_at(runtime, key::DerivedKey{F,TT}) where {F,TT}
-    storage = Salsa.storage(runtime)
+# Typed probe behind a function barrier: inside, the key's args tuple is
+# extracted unboxed and the dict lookup is fully typed. The (single) dynamic
+# dispatch here allocates nothing — both arguments are already heap values.
+# NOTE: `DerivedValue{Any}` here (and the assert below) relies on `RT = Any`
+# in `_memoized_lookup_internal`; strongly typing the value would break these.
+_probe_derived(map::Dict{TT,DerivedValue{Any}}, key::DerivedKey{F,TT}) where {F,TT} =
+    get(map, key.args, nothing)
+
+function _derived_changed_at(runtime, storage::DefaultStorage, @nospecialize(key::DerivedKey))::Revision
     local v
     @lock storage.lock begin
-        map = get(storage.derived_function_maps, DerivedKey{F,TT}, nothing)
-        v = map === nothing ? nothing : get(map::Dict{TT,DerivedValue{Any}}, key.args, nothing)
+        map = get(storage.derived_function_maps, typeof(key), nothing)
+        v = map === nothing ? nothing : _probe_derived(map, key)
     end
     v === nothing && return _changed_at(memoized_lookup(runtime, key))
+    v = v::DerivedValue{Any}
     v.verified_at == storage.current_revision && return v.changed_at
     for dep in v.dependencies
-        if key_changed_at(runtime, dep) > v.verified_at
+        if _key_changed_at(runtime, storage, dep) > v.verified_at
             return _changed_at(memoized_lookup(runtime, key))
         end
     end

--- a/src/runtime_tracing.jl
+++ b/src/runtime_tracing.jl
@@ -71,9 +71,16 @@ end
 
 ########## Implementation of Runtime API
 
-context(rt::_TracingRuntime) = unsafe_load(rt.tl_runtime).context
+# NOTE: `unsafe_load` on a Ptr to a mutable struct materializes a *copy*
+# (one allocation per call, and these are called on every lookup); the
+# pointer came from `pointer_from_objref`, so recover the object itself.
+function _tl_runtime(rt::_TracingRuntime{CT,ST}) where {CT,ST}
+    return Base.unsafe_pointer_to_objref(Ptr{Cvoid}(rt.tl_runtime))::_TopLevelRuntime{CT,ST}
+end
 
-storage(rt::_TracingRuntime) = unsafe_load(rt.tl_runtime).storage
+context(rt::_TracingRuntime) = _tl_runtime(rt).context
+
+storage(rt::_TracingRuntime) = _tl_runtime(rt).storage
 
 trace(rt::_TracingRuntime) = get_trace(rt.immediate_dependencies_id)
 


### PR DESCRIPTION
Three allocation sources fired once per dependency edge during verification, tens of MB per whole-graph sweep — enough to draw a GC pause into most sweeps on processes with modest live heaps:

- storage()/context() on the tracing runtime used unsafe_load, which materializes a copy of the top-level runtime struct per call; recover the object via unsafe_pointer_to_objref instead (the pointer comes from pointer_from_objref, so the object is always valid here).
- key_changed_at dispatched dynamically on the parametric key type, boxing the isbits tracing runtime (and the returned Int) per edge; still_valid now threads the storage through an isa-split walk over @nospecialize'd methods, so the calls resolve statically.
- Extracting args from an unspecialized key boxes the inline tuple, and field reads through the DerivedValue UnionAll box Ints (field offsets statically unknown); a typed probe behind a one-call function barrier (_probe_derived) fixes both.

Whole-graph re-verification of a ~58k-edge graph after a single input change: ~69 MB allocated -> ~0.1 MB, in-sweep GC pauses eliminated, 129/159 ms best/median -> 102/110 ms.