### PR TITLE
Refactor trace pool implementation

### DIFF
--- a/src/default_storage.jl
+++ b/src/default_storage.jl
@@ -248,7 +248,7 @@ function Salsa._memoized_lookup_internal(
                 #   allocation and a copy by _swapping_ the `trace`'s `ordered_dependencies`
                 #   with `existing_value.dependencies`, so that the deps are written
                 #   in-place directly into their final destination! :)
-                trace = Salsa.get_trace(runtime.immediate_dependencies_id)
+                trace = Salsa.trace(runtime)
                 # Temporarily swap the dependency vectors while running user_func so the
                 # deps are recorded in-place. Note that we must swap them back at the end.
                 existing_value.dependencies, trace.ordered_deps =

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -80,13 +80,9 @@ function Base.show(io::IO, rt::_TopLevelRuntime{EmptyContext,DefaultStorage})
     print(io, "Salsa.Runtime($(rt.storage))")
 end
 
-# Initialize at top level so trace pools are available during precompilation workloads.
-_init_thread_local_pools_and_freelists()
-
 function __init__()
-    # Re-initialize at runtime with the correct thread count.
-    empty!(g_threadlocal_trace_pools)
-    empty!(g_threadlocal_trace_freelists)
-    empty!(g_threadlocal_pool_locks)
-    _init_thread_local_pools_and_freelists()
+    # Drop any traces pooled during precompilation workloads; start with empty stripes.
+    for stack in g_trace_pool_stripes
+        @atomic stack.top = nothing
+    end
 end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -81,8 +81,11 @@ function Base.show(io::IO, rt::_TopLevelRuntime{EmptyContext,DefaultStorage})
 end
 
 function __init__()
-    # Drop any traces pooled during precompilation workloads; start with empty stripes.
-    for stack in g_trace_pool_stripes
-        @atomic stack.top = nothing
+    # The runtime thread count isn't known at precompile time, so build the stripes here:
+    # one per thread id, rounded up to a power of two to keep the index mask cheap.
+    # Rebuilding also drops any traces pooled during precompilation workloads.
+    empty!(g_trace_pool_stripes)
+    for _ = 1:nextpow(2, Threads.maxthreadid())
+        push!(g_trace_pool_stripes, TraceStack())
     end
 end

--- a/src/runtime_top_level.jl
+++ b/src/runtime_top_level.jl
@@ -12,11 +12,10 @@ Runtime{CT}(ctx::CT = CT()) where {CT} = Runtime{CT,DefaultStorage}(ctx, Default
 Runtime(st) = Runtime{EmptyContext,DefaultStorage}(EmptyContext(), st)
 Runtime() = Runtime(DefaultStorage())  # Equivalent to DefaultRuntime()
 
-# This is the top-level Runtime object which users will instantiate for using Salsa. We mark
-# the _TopLevelRuntime as mutable, so that we can take its pointer_from_objref(). It will
-# very likely be not isbits anyway, since the users' storage objects are unlikely to be
-# isbits. It's a bit annoying that this is mutable, because its contents really musn't ever
-# change, but here we are.
+# This is the top-level Runtime object which users will instantiate for using Salsa.
+# NOTE: This struct no longer needs to be mutable (the old `pointer_from_objref` trick is
+# gone), but remains so for backwards compatibility with code that assumes identity
+# semantics.
 mutable struct _TopLevelRuntime{CT,ST<:AbstractSalsaStorage} <: Runtime{CT,ST}
     # Store the user-provided context object, where they can store per-runtime meta-data
     # that does not affect Salsa invalidation / re-evaluation.

--- a/src/runtime_tracing.jl
+++ b/src/runtime_tracing.jl
@@ -7,31 +7,27 @@
 # parallel on multiple threads. This makes the Runtime thread-safe, as long as it's used
 # correctly.
 struct _TracingRuntime{CT,ST<:AbstractSalsaStorage} <: Runtime{CT,ST}
-    # NOTE: We store a Ptr{} to the parent Runtime rather than the Storage instance itself,
-    # in order to keep this struct as `isbits`. This is super critical because we create a
-    # new instance of this struct on _every function call_ in Salsa!  We also use this
-    # pointer to allow derived functions to access their Runtime's context.
+    # The parent Runtime, through which derived functions access their Runtime's context
+    # and storage.
     #
-    # This is guaranteed to be safe, since the parent Runtime will always exist until the
-    # function call that created this tracing runtime has completed.
-    tl_runtime::Ptr{_TopLevelRuntime{CT,ST}}
+    # NOTE: This struct holds heap references but is itself immutable, so creating one per
+    # derived function call does not allocate (immutable structs with references are
+    # stack-allocated since Julia 1.5). The isbits/Ptr tricks previously used here are no
+    # longer needed.
+    tl_runtime::_TopLevelRuntime{CT,ST}
 
     # A trace structure to store the dependencies of derived functions as they are
-    # encountered. This field is mutable, but we create a new, empty trace every time we
-    # branch the Runtime. It's locked internally to allow spawned derived functions on
-    # separate threads to record dependencies to the parent thread.
-    #
-    # NOTE: We store an index into `tls_trace_pool()`, rather than a `TraceOfDependencyKeys`
-    # object itself here, in order to keep this struct as `isbits`. This is super critical
-    # because we create a new instance of this struct on _every function call_ in Salsa!
-    immediate_dependencies_id::TraceId
+    # encountered. The trace is mutable, but we take a fresh, empty one from the trace pool
+    # every time we branch the Runtime. It's locked internally to allow spawned derived
+    # functions on separate threads to record dependencies to the parent task's trace.
+    immediate_dependencies::TraceOfDependencyKeys
 
     function @__MODULE__().new_trace_runtime!(
         old_rt::_TopLevelRuntime{CT,ST},
         key::DependencyKey,
     )::_TracingRuntime{CT,ST} where {CT,ST<:AbstractSalsaStorage}
         new{CT,ST}(
-            reinterpret(Ptr{ST}, pointer_from_objref(old_rt)),
+            old_rt,
             # Start a new, empty trace (with the provided call stack if in debug mode)
             if Salsa.Debug.debug_enabled()
                 get_trace_with_call_stack(SalsaStackFrame(key, nothing))
@@ -71,18 +67,11 @@ end
 
 ########## Implementation of Runtime API
 
-# NOTE: `unsafe_load` on a Ptr to a mutable struct materializes a *copy*
-# (one allocation per call, and these are called on every lookup); the
-# pointer came from `pointer_from_objref`, so recover the object itself.
-function _tl_runtime(rt::_TracingRuntime{CT,ST}) where {CT,ST}
-    return Base.unsafe_pointer_to_objref(Ptr{Cvoid}(rt.tl_runtime))::_TopLevelRuntime{CT,ST}
-end
+context(rt::_TracingRuntime) = rt.tl_runtime.context
 
-context(rt::_TracingRuntime) = _tl_runtime(rt).context
+storage(rt::_TracingRuntime) = rt.tl_runtime.storage
 
-storage(rt::_TracingRuntime) = _tl_runtime(rt).storage
-
-trace(rt::_TracingRuntime) = get_trace(rt.immediate_dependencies_id)
+trace(rt::_TracingRuntime) = rt.immediate_dependencies
 
 collect_call_stack(rt::_TracingRuntime) = _collect_call_stack_frames(trace(rt).call_stack)
 _collect_call_stack_frames(::Nothing) = DependencyKey[]
@@ -91,7 +80,7 @@ _collect_call_stack_frames(frame::SalsaStackFrame) = collect(frame)
 collect_trace(rt::_TracingRuntime) = collect_trace(trace(rt))
 
 function destruct_trace!(rt::_TracingRuntime)
-    release_trace_id(rt.immediate_dependencies_id)
+    release_trace(rt.immediate_dependencies)
     return nothing
 end
 

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -46,9 +46,9 @@ mutable struct TraceOfDependencyKeys
     # We always create a new, empty TraceOfDependencyKeys for each derived function, since
     # we're only tracing the immediate dependencies of that function.
     function TraceOfDependencyKeys()
-        # Pre-allocate all traces to be non-empty, to minimize allocations at runtime.
-        # These traces are all constructed once ahead of time in the per-thread trace pools,
-        # so this initialization is only done once during Module __init__().
+        # Pre-allocate the containers to be non-empty, to minimize allocations at runtime.
+        # Traces are recycled through the trace pool, so this cost is only paid when the
+        # pool grows.
         return new(
             sizehint!(Vector{DependencyKey}(), TRACE_INITIAL_CAPACITY),
             sizehint!(Set{DependencyKey}(), TRACE_INITIAL_CAPACITY),

--- a/src/trace_pool.jl
+++ b/src/trace_pool.jl
@@ -1,140 +1,106 @@
-########## Salsa Trace Free List
+########## Salsa Trace Pool
 
-# This section defines a thread-local storage free-list for salsa derived function
-# traces. This is needed because each derived function needs its own vector to track
-# dependencies, and vectors have to be heap allocated, but allocations are expensive. We can
-# avoid those allocations by pre-allocating a pool of trace objects, and reusing them with a
-# freelist. We have one instance of pool+freelist per OS Thread, so that no locking is
-# required when taking/putting trace objects into/out of the freelist.
+# This section defines a pool of salsa derived function traces. This is needed because
+# each derived function needs its own containers to track dependencies, and those have to
+# be heap allocated, but allocations are expensive (~10 allocations / >1KiB per fresh
+# trace, dominated by the Set, Vector and ReentrantLock). We avoid that by recycling
+# released traces through a free-list and reusing them for later derived function calls.
 #
-# The implementation works as follows:
-# On each thread we keep a pool and a freelist:
-#   - The pool stores all the TraceOfDependencyKeys objects that are allocated, and
-#   - The freelist stores _indexes_ into that pool vector, representing traces that are
-#     free to use.
+# The free-list is implemented as a set of *Treiber stacks*: lock-free stacks where the
+# `top` pointer is an atomic field, and push/pop are each a single compare-and-swap (CAS).
+# Any task running on any thread may acquire and release traces, so the pool is safe under
+# task migration (unlike the previous design, which indexed per-thread pools by
+# `Threads.threadid()` and corrupted its free-lists when a task migrated between acquire
+# and release, or even mid-acquire).
 #
-# When a derived function starts, it takes an index out of the freelist, which is stored in
-# the instance of the _TracingRuntime. Then, while executing user code, when any subsequent
-# derived functions are called (bringing us back into the Salsa codebase), we access the
-# trace via the provided index, and register the newly called derived function dependency.
+# ABA safety: the classic hazard of a Treiber stack is a stale `next` pointer being
+# CAS'd back in after the node it was read from has been popped, *recycled*, and pushed
+# again. We are immune because nodes are never recycled: `release_trace` wraps the trace
+# in a freshly allocated node (32 bytes), and the GC guarantees a node cannot be
+# reallocated while another task still holds a reference to it.
 #
-# We use an Int index rather than simply a reference to the trace itself in order to ensure
-# that `_TracingRuntime` remains isbits, since we create one instance per derived function
-# call, and if it is not isbits, it will incur allocations.
+# Striping: all tasks CASing a single `top` pointer would contend under wide task
+# parallelism, so we keep several independent stacks ("stripes") and select one by the
+# identity of the current task. This is purely load-spreading; any task may pop from a
+# stripe that a different task pushed to.
 #
-# When the derived function call finishes, we copy the dependencies out of the trace, clear
-# it, and put its index back into the freelist. If we ever attempt to take out a new index,
-# but the pool is empty, the pool will be doubled with new traces. This should be fairly
-# rare, since it will only happen the first time we exceed some number of derived functions
-# in flight.
+# The pool starts empty and grows organically: if a task finds its stripe empty, it simply
+# allocates a fresh trace, which enters the pool when released. Steady-state pool size is
+# therefore the high-water mark of concurrently-live traces (rather than a fixed
+# per-thread pre-allocation).
 #
 # NOTE: In the future, we intend to rewrite Salsa to use a Stack, as depth-first-search,
 # rather than using function calls as we do now. Based on our early sketches, we think such
 # a design will allow us to remove all of this silliness since each Salsa Task will have its
 # own local variables that can be freely reused, much more simply. For now, this suffices.
 
-const g_threadlocal_trace_pools = Vector{TraceOfDependencyKeys}[]
-const g_threadlocal_trace_freelists = Vector{Int}[]
-const g_threadlocal_pool_locks = Base.ReentrantLock[]
-
-# Start off with some large number of traces in the pool. This is arbitrary, but we want it
-# to be big enough where it doesn't have to get doubled very often. The traces will double
-# whenever we have more active derived functions than available traces, which should only
-# happen for very-long chains of derived functions or very-wide task parallelism.
-const N_INIT_TRACES = 512
-
-# This function is called in Salsa.__init__() because we don't know the
-# number of threads until runtime. (__init__() is defined at the end of this file.)
-# Use maxthreadid() when available (Julia 1.11+) to account for interactive/GC threads
-# whose IDs exceed nthreads().
-_num_thread_slots() = isdefined(Base.Threads, :maxthreadid) ? Threads.maxthreadid() : Threads.nthreads()
-function _init_thread_local_pools_and_freelists()
-    n = _num_thread_slots()
-    append!(
-        g_threadlocal_trace_pools,
-        TraceOfDependencyKeys[TraceOfDependencyKeys() for _ = 1:N_INIT_TRACES] for _ = 1:n
-    )
-    append!(
-        g_threadlocal_trace_freelists,
-        Int[i for i = 1:N_INIT_TRACES] for _ = 1:n
-    )
-    for _ = 1:n
-        push!(g_threadlocal_pool_locks, Base.ReentrantLock())
-    end
-    return nothing
+mutable struct TracePoolNode
+    const trace::TraceOfDependencyKeys
+    @atomic next::Union{TracePoolNode,Nothing}
+    TracePoolNode(trace::TraceOfDependencyKeys) = new(trace, nothing)
 end
 
-# Thread-safe accessors: provides one pool+freelist per OS thread.
-tls_trace_pool() = g_threadlocal_trace_pools[Threads.threadid()]
-tls_trace_freelist() = g_threadlocal_trace_freelists[Threads.threadid()]
-tls_trace_pool_lock() = g_threadlocal_pool_locks[Threads.threadid()]
-
-# This is sort of terrible, but since a _TracingRuntime can be _referenced_ from a different
-# thread than the one that created it, we need both a thread id and a trace id to retrieve
-# its trace from the new thread. Note that this is safe because the parent thread will never
-# release its trace until all children have returned, so there can be no dangling references
-# to the trace.
-struct TraceId
-    thread_idx::Int
-    trace_idx::Int
+mutable struct TraceStack
+    @atomic top::Union{TracePoolNode,Nothing}
+    TraceStack() = new(nothing)
 end
 
-# We store the call_stack in the Trace instead of in the runtime, because the trace is a
-# linked-list (meaning not isbits), and we want to keep the Runtime isbits to avoid
-# allocations. Since the Traces are pre-allocated it's okay for them to contain heap ptrs.
+const N_TRACE_POOL_STRIPES = 8  # power of two, so the modulus below is a bit-mask
+const g_trace_pool_stripes = [TraceStack() for _ = 1:N_TRACE_POOL_STRIPES]
+
+# Stripe selection must not use `Threads.threadid()` (unstable across yield points due to
+# task migration). `objectid` of the current task is stable for the task's lifetime; the
+# low bits are shifted off since heap alignment makes them constant.
+@inline function _trace_pool_stripe()::TraceStack
+    idx = (objectid(current_task()) >> 4) % N_TRACE_POOL_STRIPES + 1
+    return @inbounds g_trace_pool_stripes[idx]
+end
+
+# We store the call_stack in the Trace instead of in the runtime because the trace is
+# already mutable, while the runtime is immutable.
 @inline function get_trace_with_call_stack(call_stack::Union{SalsaStackFrame,Nothing})
-    trace_id = get_free_trace_id()
-    get_trace(trace_id).call_stack = call_stack
-    return trace_id
+    trace = _acquire_trace!()
+    trace.call_stack = call_stack
+    return trace
 end
 
-function get_trace(id::TraceId)
-    return g_threadlocal_trace_pools[id.thread_idx][id.trace_idx]
+function _acquire_trace!()::TraceOfDependencyKeys
+    stack = _trace_pool_stripe()
+    while true
+        node = @atomic :acquire stack.top
+        # Empty stripe: grow the pool by allocating a fresh trace. (It joins the pool
+        # when released.)
+        node === nothing && return TraceOfDependencyKeys()
+        next = @atomic :monotonic node.next
+        _, ok = @atomicreplace :acquire_release :monotonic stack.top node => next
+        ok && return node.trace
+    end
 end
 
-function get_free_trace_id()::TraceId
-    trace_freelist = tls_trace_freelist()
-    trace_pool = tls_trace_pool()
-    if isempty(trace_freelist)
-        # Even with a thread-local pool we could potentially run into race conditions here
-        # if we didn't lock around this section, when multiple tasks on the same thread
-        # attempt to grow the pool but block inside this function on e.g. the `@info` call.
-        @lock tls_trace_pool_lock() begin
+function release_trace(trace::TraceOfDependencyKeys)
+    empty_trace!(trace)
+    # A fresh node per push is what makes the stack ABA-safe; see the note above.
+    node = TracePoolNode(trace)
+    stack = _trace_pool_stripe()
+    while true
+        old = @atomic :monotonic stack.top
+        @atomic :monotonic node.next = old
+        _, ok = @atomicreplace :acquire_release :monotonic stack.top old => node
+        ok && return nothing
+    end
+end
 
-            # Because we only acquire the lock once we've noticed the empty freelist, we can
-            # have multiple tasks ending up in the critical section here, one after
-            # another. Of course only the first one should actually perform the doubling. We
-            # therefore have to check again whether the freelist is still empty. The
-            # alternative would be to lock _before_ checking if the freelist is empty, but
-            # that seems like unnecessary overhead since the empty freelist should be a very
-            # rare occurrence.
-            if !isempty(trace_freelist)
-                return TraceId(Threads.threadid(), pop!(trace_freelist))
-            end
-
-            @debug_mode @info "DOUBLING SALSA TRACE POOL ON THREAD $(Threads.threadid())"
-            old_size = length(trace_pool)
-            num_new_traces = old_size # Double the pool
-            @debug_mode @assert num_new_traces > 0
-            # Grow the pool:
-            append!(
-                trace_pool,
-                TraceOfDependencyKeys[TraceOfDependencyKeys() for _ = 1:num_new_traces],
-            )
-            for i = (old_size + 1) : (old_size + num_new_traces)
-                push!(trace_freelist, i)
-            end
+# Internal: snapshot of all currently-pooled traces (for tests/debugging only).
+function _pooled_traces()::Vector{TraceOfDependencyKeys}
+    traces = TraceOfDependencyKeys[]
+    for stack in g_trace_pool_stripes
+        node = @atomic stack.top
+        while node !== nothing
+            push!(traces, node.trace)
+            node = @atomic node.next
         end
     end
-    return TraceId(Threads.threadid(), pop!(trace_freelist))
-end
-
-function release_trace_id(id::TraceId)
-    @assert id.thread_idx === Threads.threadid()
-    # NOTE: no locking is needed here because this is all happening per-thread.
-    empty_trace!(tls_trace_pool()[id.trace_idx])
-    push!(tls_trace_freelist(), id.trace_idx)
-    return nothing
+    return traces
 end
 
 # Traces that recorded more than this many dependencies get fresh containers on
@@ -160,6 +126,8 @@ function empty_trace!(trace::TraceOfDependencyKeys)
     # replacement below, leaving `seen_deps` and `ordered_deps` inconsistent for
     # the trace's next user. Uncontended in correct usage, so this is cheap.
     @lock trace.lock begin
+        # Don't retain the call-stack linked list while parked in the pool.
+        trace.call_stack = nothing
         # The dependency-array swap optimization in `_memoized_lookup_internal`
         # can leave `ordered_deps` empty while `seen_deps` still holds every
         # recorded key, so both containers must be considered.

--- a/src/trace_pool.jl
+++ b/src/trace_pool.jl
@@ -19,10 +19,12 @@
 # in a freshly allocated node (32 bytes), and the GC guarantees a node cannot be
 # reallocated while another task still holds a reference to it.
 #
-# Striping: all tasks CASing a single `top` pointer would contend under wide task
-# parallelism, so we keep several independent stacks ("stripes") and select one by the
-# identity of the current task. This is purely load-spreading; any task may pop from a
-# stripe that a different task pushed to.
+# Striping: all threads CASing a single `top` pointer would contend, so we keep one
+# independent stack ("stripe") per thread id, sized in `__init__` once the runtime thread
+# count is known. This is purely load-spreading; any thread may pop from a stripe that a
+# different thread pushed to, so it is harmless that `Threads.threadid()` can change
+# across yield points, and that threads adopted after startup (whose ids exceed the
+# init-time count) wrap onto shared stripes via the index mask.
 #
 # The pool starts empty and grows organically: if a task finds its stripe empty, it simply
 # allocates a fresh trace, which enters the pool when released. Steady-state pool size is
@@ -45,14 +47,15 @@ mutable struct TraceStack
     TraceStack() = new(nothing)
 end
 
-const N_TRACE_POOL_STRIPES = 8  # power of two, so the modulus below is a bit-mask
-const g_trace_pool_stripes = [TraceStack() for _ = 1:N_TRACE_POOL_STRIPES]
+# Placeholder size for precompile time; `__init__` resizes to cover every thread id.
+# Never empty: an empty array would make the mask below -1 (i.e. `@inbounds` UB) for
+# anything touching the pool before `__init__`, such as a future precompile workload.
+# The length is always a power of two (so the modulus below is a bit-mask) and never
+# changes after `__init__`, which makes the unsynchronized `length` read below safe.
+const g_trace_pool_stripes = [TraceStack()]
 
-# Stripe selection must not use `Threads.threadid()` (unstable across yield points due to
-# task migration). `objectid` of the current task is stable for the task's lifetime; the
-# low bits are shifted off since heap alignment makes them constant.
 @inline function _trace_pool_stripe()::TraceStack
-    idx = (objectid(current_task()) >> 4) % N_TRACE_POOL_STRIPES + 1
+    idx = Threads.threadid() & (length(g_trace_pool_stripes) - 1) + 1
     return @inbounds g_trace_pool_stripes[idx]
 end
 

--- a/test/test_salsa.jl
+++ b/test/test_salsa.jl
@@ -21,7 +21,9 @@
         return out
     end
 
-    const NUM_TRACE_TEST_CALLS = Salsa.N_INIT_TRACES + 5  # Plus a few extra for good measure.
+    # Deep enough to exhaust any pooled traces and force the pool-growth (fresh
+    # allocation) path many times over.
+    const NUM_TRACE_TEST_CALLS = 517
 end
 
 # NOTE: This test file expects `new_test_rt([ctx,])` to be defined before it is called,
@@ -431,7 +433,7 @@ end
 
 
 # NOTE: This test is testing internal aspects of the package, not the public API.
-@testitem "Growing the trace pool freelist" setup=[SalsaSetup] begin
+@testitem "Growing the trace pool" setup=[SalsaSetup] begin
     using .SalsaSetup: new_test_rt
 
     @derived function recursive_cause_pool_growth(rt, n::Int)::Int
@@ -449,8 +451,8 @@ end
 
     set_base_value!(rt, 0)
 
-    # Create more than Salsa.N_INIT_TRACES derived function calls to force a growth
-    # event of the trace pool + freelist.
+    # Create a deep chain of derived function calls to force the pool to grow (an empty
+    # stripe allocates a fresh trace, which joins the pool on release).
     @test recursive_cause_pool_growth(rt, 1) == SalsaSetup.NUM_TRACE_TEST_CALLS
 
     # Now test that the dependencies were recorded correctly, and everything reruns
@@ -756,8 +758,7 @@ end
     # single wide derived function would tax every later lookup that reuses its
     # pooled trace.
     max_slots = maximum(
-        length(tr.seen_deps.dict.slots)
-        for pool in Salsa.g_threadlocal_trace_pools for tr in pool
+        length(tr.seen_deps.dict.slots) for tr in Salsa._pooled_traces()
     )
     @test max_slots <= 4 * Salsa.TRACE_CONTAINER_SHRINK_THRESHOLD
 


### PR DESCRIPTION
The old implementation was incorrect under newer Julia version task migration across threads. The old implementation also worked around compiler limits that are no longer present in more modern Julia versions, so all the stuff where pointers instead of references were stored are no longer needed.

~~I'm going to incorporate a variant of #59 into this as well.~~ Actually, lets just merge this one first, and then we can rebase that an incorporate later. Fable is of the opinion that it should be easy and compose well.

Fixes https://github.com/julia-vscode/Salsa.jl/issues/37, fixes https://github.com/julia-vscode/Salsa.jl/issues/36.